### PR TITLE
fix: wait for Docusaurus <details> expand animation before capturing

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -295,18 +295,27 @@ async function doOnePage(
 
   // Get the HTML string of the content section.
   const html = await page.evaluate(
-    ({ contentSelector, baseUrlForLinks }) => {
+    async ({ contentSelector, baseUrlForLinks }) => {
       const element: HTMLElement | null =
         document.querySelector(contentSelector);
       if (element) {
         // Add pageBreak for PDF
         element.style.pageBreakAfter = 'always';
 
-        // Open <details> tag
+        // Open every <details> so its content is captured, then wait for
+        // Docusaurus's expand animation to finish before serializing.
+        // Docusaurus reveals collapsed content asynchronously after the `open`
+        // attribute changes (see facebook/docusaurus#12277), so reading
+        // immediately would capture still-collapsed markup and hide it in the
+        // PDF. The animation scales with content height but is well under a
+        // second for typical blocks; 2s is generous headroom.
         const detailsArray = element.getElementsByTagName('details');
-        Array.from(detailsArray).forEach((element) => {
-          element.open = true;
+        Array.from(detailsArray).forEach((details) => {
+          details.open = true;
         });
+        if (detailsArray.length > 0) {
+          await new Promise((resolve) => setTimeout(resolve, 2000));
+        }
 
         if (baseUrlForLinks && baseUrlForLinks.length > 0) {
           // Replace absolute path links (starting with /) with full URLs


### PR DESCRIPTION
## What

When generating a PDF from a Docusaurus site, content inside collapsible `<details>` blocks was being dropped. `doOnePage` set `element.open = true` on every `<details>` and then read `element.outerHTML` **synchronously in the same `page.evaluate`**.

Docusaurus doesn't reveal collapsed `<details>` content from the `open` attribute alone — it syncs React state from the native `toggle` event and animates the content open *asynchronously* (see [facebook/docusaurus#12277](https://github.com/facebook/docusaurus/pull/12277)). So reading `outerHTML` immediately captured still-collapsed markup, and the content never made it into the PDF.

## Change

Made the extraction `page.evaluate` callback `async`: it still sets `.open = true` on every `<details>`, then — only if the page has any — awaits a short in-browser delay so the expand animation can finish before `outerHTML` is serialized.

## Verification

Reproduced end-to-end against a Docusaurus site built with the `#12277` fix ported in:
- **Before** (synchronous read): the collapsible block's text was absent from the generated PDF.
- **After** (this change): the collapsible text is present in the PDF; always-visible text is unaffected.

## Notes

- This is only effective once the target docs site runs a Docusaurus release that includes `#12277` (currently main-only; no release/canary yet). Without it, collapsible content stays hidden regardless.
- The wait is a fixed pause (generous headroom over the typical sub-second animation). A pathologically tall `<details>` whose animation exceeds it could still clip; the fix there is to bump the constant.
- Unrelated observation while testing: `page.pdf()` hangs indefinitely under new-headless Chrome 126 in this environment (even on a trivial page); classic `chrome-headless-shell` works. Not addressed here — worth a separate follow-up.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) (Opus 4.8)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/docu-pdf/11)
<!-- Reviewable:end -->
